### PR TITLE
Corrections

### DIFF
--- a/theme/messages_sv.properties
+++ b/theme/messages_sv.properties
@@ -20,16 +20,16 @@
 child-registration-not-allowed=Vi kan inte skapa ett konto åt dig. Din förälder eller förmyndare kan skapa ett konto åt dig. Ange deras e-postadress så kommer vi skicka en förfrågan till dem om att skapa ditt konto.
 complete-registration=Slutför registreringen
 create-an-account=Skapa ett konto
-device-form-title=Logga in enhet
-device-login-complete=Anslutningen till enheten lyckades
+device-form-title=Enhetsinloggning
+device-login-complete=Anslutningen till enheten lyckades.
 device-title=Anslut din enhet
 dont-have-an-account=Har du inget konto?
-email-verification-complete=Tack. Din e-postadress har nu bekräftats.
-email-verification-complete-title=E-postadressen är bekräftad
+email-verification-complete=Tack. Din e-postadress har bekräftats.
+email-verification-complete-title=E-post bekräftad
 email-verification-form=Fyll i formuläret för att begära en ny bekräftelse av din e-postadress.
-email-verification-form-title=Bekräftelse av e-postadress
+email-verification-form-title=Bekräftelse av e-post
 email-verification-sent=Vi har skickat e-post till %s med en verifieringskod. Följ instruktionerna i mejlet för att bekräfta din e-postadress.
-email-verification-sent-title=Begäran om bekräftelse skickad
+email-verification-sent-title=Begäran skickad
 forgot-password=Glömt lösenordet? Ange din e-postadress i formuläret nedan för att nollställa ditt lösenord.
 forgot-password-email-sent=Vi har skickat e-post till dig med en länk som möjliggör nollställning av ditt lösenord. När du fått mejlet följ instruktionerna i det för att ändra ditt lösenord.
 forgot-password-email-sent-title=E-post skickat
@@ -45,21 +45,21 @@ parent-notified=Vi har skickat e-post till din förälder. Hen kan skapa ett kon
 parent-notified-title=Förälder meddelad
 password-alpha-constraint=Måste innehålla minst ett specialtecken som inte är en bokstav eller en siffra
 password-case-constraint=Måste innehålla både små och stora bokstäver
-password-change-title=Uppdatera ditt lösenord
-password-changed=Ditt lösenord har uppdaterats.
-password-changed-title=Lösenord uppdaterat
+password-change-title=Ändra lösenord
+password-changed=Ditt lösenord har ändrats.
+password-changed-title=Lösenord ändrat
 password-constraints-intro=Lösenord måste uppfylla följande krav:
 password-length-constraint=Måste vara mellan %s och %s tecken långt
 password-number-constraint=Måste innehålla minst en siffra
 password-previous-constraint=Får inte vara exakt samma som de %s senaste lösenorden(t)
 passwordless-login=Lösenordsfri inloggning
 passwordless-button-text=Logga in med en magisk länk
-provide-parent-email=Tillhandahålla förälders e-postadress
+provide-parent-email=Uppge förälders e-post
 registration-verification-complete=Tack. Din registrering har bekräftats.
-registration-verification-complete-title=Registreringen har bekräftats
+registration-verification-complete-title=Registrering bekräftad
 registration-verification-sent=Vi har skickat e-post till %s med en verifieringskod. Följ instruktionerna i mejlet för att bekräfta din registreringsadress.
-registration-verification-sent-title=Begäran om bekräftelse skickad
-registration-verification-title=Bekräfta din registrering
+registration-verification-sent-title=Begäran skickad
+registration-verification-title=Bekräfta registrering
 send-another-code=Skicka en ny kod
 send-code-to-phone=Skicka en kod till din mobiltelefon
 sign-in-as-different-user=Logga in som en annan användare
@@ -67,6 +67,7 @@ two-factor-challenge=Tvåfaktorsinloggning
 trust-computer=Lita på den här datorn i %s dagar
 wait-title=Slutför inloggningen i din kopplade externa enhet
 waiting=Väntar
+return-to-login=Återgå till inloggningen
 
 
 #
@@ -80,29 +81,29 @@ sent-code=Kod är skickad
 # Labels for form fields. You can change the key names to anything you like but ensure that you don't change the name of the form fields.
 #
 birthDate=Födelsedatum
-code=Ange verifieringskoden
-email=E-post
+code=Ange tvåfaktorskoden
+email=E-postadress
 firstName=Förnamn
 fullName=Fullständigt namn
 lastName=Efternamn
-loginId=E-post
+loginId=E-postadress
 middleName=Mellannamn
 mobilePhone=Mobiltelefon
 password=Lösenord
 passwordConfirm=Bekräfta lösenord
-parentEmail=Förälders e-post
-register=Registrera
+parentEmail=Förälders e-postadress
+register=Skapa inloggning
 send=Skicka
-submit=Spara
+submit=Ok
 username=Användarnamn
-userCode=Ange din användarkod
-verify=Bekräfta
+userCode=Ange tvåfaktorskoden:
+verify=Verifiera
 
 
 #
 # Tooltips. You can change the key names and values to anything you like.
 #
-{tooltip}trustComputer=Välj inte inte detta på en publik dator. Att lita på denna dator innebär att tvåfaktorsinloggningen kan förbigås under den valda tidsperioden
+{tooltip}trustComputer=Välj inte detta på en publik dator. Att lita på denna dator innebär att tvåfaktorsinloggningen kan förbigås under den valda tidsperioden
 
 
 #
@@ -117,7 +118,7 @@ verify=Bekräfta
 [blank]parentEmail=Krävs
 [blank]password=Krävs
 [blank]user_code=Krävs
-[invalid]user_code=Felaktig användarkod
+[invalid]user_code=Felaktig tvåfaktorskod
 [notEqual]password=Lösenorden matchar inte
 [onlyAlpha]password=Lösenord måste innehålla minst ett specialtecken som inte är en bokstav eller en siffra
 [previouslyUsed]password=Lösenordet har nyligen använts
@@ -130,7 +131,7 @@ verify=Bekräfta
 [missing]user.birthDate=Krävs
 [couldNotConvert]user.birthDate=Ogiltig
 [blank]user.email=Krävs
-[notEmail]user.email=Felaktig e-post
+[notEmail]user.email=Felaktig e-postadress
 [duplicate]user.email=Det finns redan ett konto med e-postadressen
 [inactive]user.email=Det finns redan ett konto med e-postadressen men det är låst. Kontakta supporten för hjälp
 [blank]user.firstName=Krävs


### PR DESCRIPTION
- Shorter titles
- Correction of Swenglish to proper Swedish
- "Usercode" translates to "two factor code" in OAuth context
- Add punctuation, when missing, for being consequent
- Minor corrections
- Use "Ok" for submit-buttons, since "Spara" means "Save" – and that won't make sense all the time