### PR TITLE
Polish translations redaction

### DIFF
--- a/theme/messages_pl.properties
+++ b/theme/messages_pl.properties
@@ -17,7 +17,7 @@
 #
 # Text used on the page (inside the HTML). You can create new key-value pairs here and use them in the templates.
 #
-child-registration-not-allowed=Nie możemy utworzyć dla ciebie konta. Twój rodzic lub opiekun może to dla ciebie zrobić. Podaj ich adres mailowy a my poprosimy ich o utworzenie dla ciebie konta.
+child-registration-not-allowed=Nie możemy utworzyć dla ciebie konta. Twój rodzic lub opiekun może to dla ciebie zrobić. Podaj ich adres email a my poprosimy ich o utworzenie dla ciebie konta.
 complete-registration=Dokończ rejestrację
 create-an-account=Utwórz konto
 complete-external-login=Dokończ logowanie na swoim urządzeniu
@@ -25,41 +25,41 @@ device-form-title=Podłącz urządzenie
 device-login-complete=Pomyślnie połączono urządzenie z twoim kontem
 device-title=Połącz urządzeniem ze swoim kontem
 dont-have-an-account=Nie masz konta?
-email-verification-complete=Dziękujemy. Twój email został zweryfikowany.
-email-verification-complete-title=Weryfikacja emaila zakończona
-email-verification-form=Wypełnij ten formularz aby rozpocząć nową weryfikcję emaila.
-email-verification-form-title=Weryfikcję emaila
-email-verification-sent=Wysłaliśmy emaila na %s z twoim kodem weryfikacyjnym. Postępuj zgodnie z instrukcją zawartą w mailu aby dokończyć weryfikację.
-email-verification-sent-title=Weryfikacja wysłana
-forgot-password=Nie pamiętasz hasła? Wpisz twój adress email w poniższym formularzu aby zresetować hasło.
+email-verification-complete=Dziękujemy. Twój adres email został zweryfikowany.
+email-verification-complete-title=Weryfikacja adresu email zakończona
+email-verification-form=Wypełnij ten formularz aby rozpocząć nową weryfikację adresu email.
+email-verification-form-title=Weryfikacja adresu email
+email-verification-sent=Wysłaliśmy wiadomość email z twoim kodem weryfikacyjnym na adres %s. Postępuj zgodnie z instrukcją zawartą w mailu aby dokończyć weryfikację.
+email-verification-sent-title=Wiadomość weryfikacyjna wysłana
+forgot-password=Nie pamiętasz hasła? Wpisz swój adres email w poniższym formularzu aby zresetować hasło.
 forgot-password-email-sent=Wysłaliśmy ci email zawierający link pozwalający zresetować twoje hasło. Postępuj zgodnie z instrukcją zawartą w mailu aby zmienić twoje hasło.
-forgot-password-email-sent-title=Email wysłany
+forgot-password-email-sent-title=Wiadomość email wysłana
 forgot-password-title=Nie pamiętam hasła
 forgot-your-password=Nie pamiętasz hasła?
 help=Pomoc
-login=Login
+login=Zaloguj się
 logging-out=Wylogowywanie
 logout-title=Wylogowywanie
 next=Dalej
 or=Lub
-parent-notified=Wysłaliśmy email do twojego rodzica. On może stwożyć ci konto.
+parent-notified=Wysłaliśmy wiadomość email do twojego rodzica. On może stworzyć ci konto.
 parent-notified-title=Rodzic powiadomiony
 password-alpha-constraint=Musi zawierać przynajmniej jeden znak niealfanumeryczny.
 password-case-constraint=Musi zawierać małe i wielkie litery
-password-change-title=Zaaktualizuj hasło
-password-changed=Twoje hasło zostało zmienioe.
+password-change-title=Zaktualizuj hasło
+password-changed=Twoje hasło zostało zmienione.
 password-changed-title=Hasło zmienione.
 password-constraints-intro=Hasło musi spełniać następujące wymagania:
 password-length-constraint=Musi zawierać pomiędzy %s a %s znaków
 password-number-constraint=Musi zawierać przynajmniej jedną cyfrę
 password-previous-constraint=Nie może być takie jak %s poprzednich haseł
-passwordless-login=Login bezhasłowy
+passwordless-login=Logowanie bezhasłowe
 passwordless-button-text=Zaloguj używając magicznego linka
-provide-parent-email=Podaj email rodzica
+provide-parent-email=Podaj adres email rodzica
 registration-verification-complete=Dziękujemy. Twoja rejestracja została zweryfikowana.
 registration-verification-complete-title=Weryfikacja rejestracji zakończona
-registration-verification-sent=Wysłaliśmy emaila na %s z twoim kodem weryfikacyjnym. Postępuj zgodnie z instrukcją zawartą w mailu aby dokończyć weryfikację.
-registration-verification-sent-title=Weryfikacja wysłana
+registration-verification-sent=Wysłaliśmy wiadomość email z twoim kodem weryfikacyjnym na adres %s. Postępuj zgodnie z instrukcją zawartą w mailu aby dokończyć weryfikację.
+registration-verification-sent-title=Wiadomość weryfikacyjna wysłana
 registration-verification-title=Weryfikacja rejestracji
 return-to-login=Powrót do logowania
 send-another-code=Wyślij kod ponownie
@@ -81,7 +81,7 @@ sent-code=Kod został wysłany
 #
 # Labels for form fields. You can change the key names to anything you like but ensure that you don't change the name of the form fields.
 #
-birthDate=Data urodzenina
+birthDate=Data urodzenia
 code=Wprowadź kod weryfikacyjny
 email=Email
 firstName=Imię
@@ -104,14 +104,14 @@ verify=Zweryfikuj
 #
 # Tooltips. You can change the key names and values to anything you like.
 #
-{tooltip}trustComputer=Nie zaznaczaj tej opcji na komputerze publicznym. Ufanie temu komputerowi pozwoli ominąć dwyskładnikową autentykację na podany czas
+{tooltip}trustComputer=Nie zaznaczaj tej opcji na komputerze publicznym. Ufanie temu komputerowi pozwoli ominąć uwierzytelnianie dwuskładnikowe na podany czas
 
 
 #
 # Validation errors when forms are invalid. The format is [<error-code>]<field-name>. These are hard-coded in the FusionAuth code and the
 # keys cannot be changed. You can still change the values though.
 #
-[invalid]applicationId=Podana wartość application id jest nieprawidłowa.
+[invalid]applicationId=Podany identyfikator aplikacji jest nieprawidłowy.
 [blank]code=Wymagane
 [invalid]code=Kod nieprawidłowy
 [blank]email=Wymagane
@@ -133,8 +133,8 @@ verify=Zweryfikuj
 [couldNotConvert]user.birthDate=Błędna data
 [blank]user.email=Wymagane
 [notEmail]user.email=Błędny email
-[duplicate]user.email=Konto z tym emailem już istnieje
-[inactive]user.email=Konto z tym emailem już istnieje ale jest ono zablokowane. Skontaktuj się z administratorem o wsparcie
+[duplicate]user.email=Konto z tym adresem email już istnieje
+[inactive]user.email=Konto z tym adresem email już istnieje ale jest ono zablokowane. Skontaktuj się z administratorem lub działem pomocy w celu uzyskania wsparcia.
 [blank]user.firstName=Wymagane
 [blank]user.fullName=Wymagane
 [blank]user.lastName=Wymagane
@@ -144,14 +144,14 @@ verify=Zweryfikuj
 [blank]user.parentEmail=Wymagane
 [blank]user.password=Wymagane
 [doNotMatch]user.password=Hasła się różnią
-[singleCase]user.password=Hasło musi zawierać małe i wielke litery
+[singleCase]user.password=Hasło musi zawierać małe i wielkie litery
 [onlyAlpha]user.password=Hasło musi zawierać znak interpunkcyjny
 [requireNumber]user.password=Hasło musi zawierać cyfrę
 [tooShort]user.password=Hasło jest zbyt krótkie
 [tooLong]user.password=Hasło przekracza maksymalną długość
 [blank]user.username=Wymagane
 [duplicate]user.username=Konto z tą nazwą użytkownika już istnieje
-[inactive]user.username=Konto z tą nazwą użytkownika już istnieje ale jest ono zablokowane. Skontaktuj się z administratorem po wsparcie
+[inactive]user.username=Konto z tą nazwą użytkownika już istnieje ale jest ono zablokowane. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [moderationRejected]user.username=Ta nazwa użytkownika nie może być użyta. Spróbuj innej.
 
 #
@@ -177,35 +177,35 @@ verify=Zweryfikuj
 #
 [APIError]=Wystąpił nieoczekiwany błąd.
 [AdditionalFieldsRequired]=Dodatkowe pola są wymagane aby dokończyć twoją rejestrację.
-[EmailVerificationDisabled]=Weryfikacja email jest obecnie wyłączona. Skontaktuj się z administratorem po wsparcie.
+[EmailVerificationDisabled]=Weryfikacja adresu email jest obecnie wyłączona. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [ErrorException]=Wystąpił nieoczekiwany błąd.
-[ForgotPasswordDisabled]=Obsługa zapomnianych haseł nie jest włączona. Skontaktuj się z administratorem po wsparcie.
+[ForgotPasswordDisabled]=Obsługa zapomnianych haseł nie jest włączona. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [InvalidChangePasswordId]=Twój kod resetu hasła wygasł lub jest błędny.
-[InvalidEmail]=Użytkownik o tym emailu nie został odnaleziony.
-[InvalidIdentityProviderId]=Błędne zapytanie. Nie można obsłużyć logowania dostawcy tożsamości. Skontaktuj się z administratorem po wsparcie.
+[InvalidEmail]=Użytkownik o tym adresie email nie został odnaleziony.
+[InvalidIdentityProviderId]=Błędne zapytanie. Nie można obsłużyć logowania dostawcy tożsamości. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [InvalidLogin]=Nieprawidłowe dane logowania.
 [InvalidVerificationId]=Zapytanie zawiera nieprawidłowy lub wygasły identyfikator weryfikacji. Poproś o wysłanie ponownej weryfikacji.
-[LoginPreventedException]=Twoje konto zostało zablokowane. Skontaktuj się z administratorem po wsparcie.
+[LoginPreventedException]=Twoje konto zostało zablokowane. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [MissingApplicationId]=Wartość applicationId jest wymagana lecz zabrakło jej w zapytaniu.
 [MissingChangePasswordId]=Wartość changePasswordId jest wymagana lecz zabrakło jej w zapytaniu.
 [MissingEmail]=Adres email jest wymagany lecz zabrakło go w zapytaniu.
-[MissingEmailAddressException]=Musisz posiadać adres email aby skożystać z loginu bezhasłowego.
-[MissingVerificationId]=Wartość verification Id nie została wyślana w tym zapytaniu.
-[NotFoundException]=Wymagana konfiguracja OAuth jest nieprawidłowa.
-[OAuthv1TokenMismatch]=Błędne zapytanie. Token podany w callback-u w OAuth v1 nie był tym wysłanym podaczas autoryzacji. Nie można obsłużyć loginu dostawcy tożsamości. Skontaktuj się z administratorem po wsparcie. 
+[MissingEmailAddressException]=Musisz posiadać adres email aby skorzystać z loginu bezhasłowego.
+[MissingVerificationId]=Identyfikator weryfikacji nie został wysłana w tym zapytaniu.
+[NotFoundException]=Podana konfiguracja OAuth jest nieprawidłowa.
+[OAuthv1TokenMismatch]=Błędne zapytanie. Token podany w callback-u OAuth v1 nie był tym wysłanym podczas autoryzacji. Nie można obsłużyć procesu logowania dostawcy tożsamości. Skontaktuj się z administratorem lub działem pomocy w celu uzyskania wsparcia. 
 [Oauthv2Error]=Nieprawidłowe zapytanie zostało wykonane na endpoint Authorize. %s
-[PasswordlessRequestSent]=Email jest w drodze.
+[PasswordlessRequestSent]=Wiadomość email jest w drodze.
 [PasswordChangeRequired]=Musisz zmienić hasło aby kontynuować.
 [PasswordChangeReasonExpired]=Twoje hasło wygasło i musi być zmienione.
 [PasswordChangeReasonBreached]=Twoje hasło zostało odnalezione w wyciekach danych i musi być zmienione.
 [PasswordChangeReasonValidation]=Twoje hasło nie spełnia wymagań bezpieczeństwa i musi być zmienione.
 [PasswordChangedSinceLastLogin]=Twoje hasło zostało zmienione od ostatniego logowania. Nastąpiło wylogowanie. Zaloguj się ponownie używając nowego hasła.
 [PasswordlessDisabled]=Logowanie bezhasłowe nie jest obecnie skonfigurowane.
-[PushTwoFactorFailed]=Nie udało nam się wysłać kodu werifikacji używając skonfigurowanego serwisu push.
+[PushTwoFactorFailed]=Nie udało się nam wysłać kodu weryfikującego używając skonfigurowanego serwisu push.
 [TenantIdRequired]=FusionAuth nie jest w stanie określić podmiotu dla tego zapytania. Proszę dodaj parametr tenantId do URL-a zapytania.
 [TwoFactorTimeout]=Nie dokończyłeś wyzwania wieloskładnikowego na czas. Proszę zalogować się ponownie.
-[UserExpiredException]=Twoje konto wygasło. Skontaktuj się z administratorem po wsparcie.
-[UserLockedException]=Twoje konto zostało zablokowane. Skontaktuj się z administratorem po wsparcie.
+[UserExpiredException]=Twoje konto wygasło. Skontaktuj się z administratorem w celu uzyskania wsparcia.
+[UserLockedException]=Twoje konto zostało zablokowane. Skontaktuj się z administratorem w celu uzyskania wsparcia.
 [UserUnauthenticated]=Wygląda na to, że trafiłeś(-łaś) tu przez przypadek. Powróć do swojej aplikacji i zaloguj się aby rozpocząć autoryzację.
 [ExternalAuthenticationException]=%1$s Żądanie logowania nie powiodło się.
 [ExternalAuthenticationExpired]=Żądanie logowania przedawniło się, spróbuj ponownie.


### PR DESCRIPTION
While working on my fusionauth installation, I have stumbled on a number of typos and spelling errors in polish translation. Also some messages sounds oddly and uses semi-colloquial phrases. This pull request contains redacted version of polish translation.