### PR TITLE
Add `preferredLanguages` Localization Key

### DIFF
--- a/missing-translations/messages_da.properties
+++ b/missing-translations/messages_da.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_es.properties
+++ b/missing-translations/messages_es.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_fi.properties
+++ b/missing-translations/messages_fi.properties
@@ -96,6 +96,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_id_ID.properties
+++ b/missing-translations/messages_id_ID.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 remember-device=Keep me signed in
 update=Update
 registration.preferredLanguages=Languages

--- a/missing-translations/messages_it.properties
+++ b/missing-translations/messages_it.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_ja.properties
+++ b/missing-translations/messages_ja.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 remember-device=Keep me signed in
 update=Update
 registration.preferredLanguages=Languages

--- a/missing-translations/messages_pt_BR.properties
+++ b/missing-translations/messages_pt_BR.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 remember-device=Keep me signed in
 update=Update
 registration.preferredLanguages=Languages

--- a/missing-translations/messages_ru.properties
+++ b/missing-translations/messages_ru.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_sv.properties
+++ b/missing-translations/messages_sv.properties
@@ -94,6 +94,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/missing-translations/messages_ua.properties
+++ b/missing-translations/messages_ua.properties
@@ -95,6 +95,7 @@ webauthn-reauth-return-to-login=If you don't recognize the passkeys(s) above cli
 webauthn-reauth-select-passkey=Welcome back, click on a passkey to continue.
 listSeparator=,\u0020
 propertySeparator=:
+preferredLanguages=Languages
 register-step=Step %d of %d
 remember-device=Keep me signed in
 update=Update

--- a/theme/messages.properties
+++ b/theme/messages.properties
@@ -184,6 +184,7 @@ mobilePhone=Mobile phone
 password=Password
 passwordConfirm=Confirm password
 parentEmail=Parent's email
+preferredLanguages=Languages
 register=Register
 register-step=Step %d of %d
 remember-device=Keep me signed in

--- a/theme/messages_ar.properties
+++ b/theme/messages_ar.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -130,6 +142,7 @@ mobilePhone=الهاتف المحمول
 password=كلمة المرور
 passwordConfirm=تأكيد كلمة المرور
 parentEmail=البريد الإلكتروني للوالد
+preferredLanguages=اللغات
 register=تسجيل لأول مرة
 register-step=الخطوة %d من %d
 send=إرسال

--- a/theme/messages_de.properties
+++ b/theme/messages_de.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -106,6 +118,7 @@ middleName=Zweiter Vorname
 mobilePhone=Mobiltelefon
 password=Passwort
 passwordConfirm=Passwort bestätigen
+preferredLanguages=Sprachen
 parentEmail=E-Mail der Eltern
 register=Registrieren
 register-step=Schritt %d von %d

--- a/theme/messages_fr.properties
+++ b/theme/messages_fr.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -93,6 +105,7 @@ middleName=Deuxième prénom
 mobilePhone=Téléphone mobile
 password=Mot de passe
 passwordConfirm=Confirmer le mot de passe
+preferredLanguages=Langues
 parentEmail=Adresses email des responsables légaux
 register=S'inscrire
 send=Envoyer

--- a/theme/messages_nl.properties
+++ b/theme/messages_nl.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -178,6 +190,7 @@ mobilePhone=Mobiele telefoon
 password=Wachtwoord
 passwordConfirm=Bevestig wachtwoord
 parentEmail=Email van ouders
+preferredLanguages=Talen
 register=Registreer
 register-step=Stap %d van %d
 remember-device=Houd mij ingelogd

--- a/theme/messages_pl.properties
+++ b/theme/messages_pl.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -144,6 +156,7 @@ mobilePhone=Telefon komórkowy
 password=Hasło
 passwordConfirm=Potwierdź hasło
 parentEmail=Email rodzica
+preferredLanguages=Języki
 register=Zarejestruj
 register-step=Krok %d z %d
 remember-device=Nie wylogowuj mnie

--- a/theme/messages_zh_CN.properties
+++ b/theme/messages_zh_CN.properties
@@ -1,6 +1,18 @@
 #
 # Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
 
 #
 # Date and Time formats
@@ -151,6 +163,7 @@ mobilePhone=手机号
 password=密码
 passwordConfirm=确认密码
 parentEmail=家长的电子邮件地址
+preferredLanguages=语言
 register=注册
 register-step=第 %d 步，共 %d 步
 remember-device=记住登录状态


### PR DESCRIPTION
Add `preferredLanguages` message key for localization. Copied localized values where they were available. Others are added to missing translations.

Related (internal)
- https://github.com/FusionAuth/fusionauth-app/pull/215