### PR TITLE
refactor(messages.properties): Grammatical errors

### DIFF
--- a/theme/messages.properties
+++ b/theme/messages.properties
@@ -184,7 +184,7 @@ sent-code=Code successfully sent
 #
 # Labels for form fields. You can change the key names to anything you like but ensure that you don't change the name of the form fields.
 #
-birthDate=Birth date
+birthDate=Birthdate
 code=Enter your verification or recovery code
 email=Email
 firstName=First name
@@ -275,8 +275,8 @@ oauth2-email-enable-step-1=To enable two-factor using email, enter an email addr
 
 # SMS Enable / Disable
 sms-disable-step-1=To disable two-factor using SMS, click the button to send a one-time use code to %s. Once you receive the code, enter it in the form below.
-sms-enable-step-1=Two enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
-oauth2-sms-enable-step-1=Two enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
+sms-enable-step-1=To enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
+oauth2-sms-enable-step-1=To enable two-factor using SMS, enter a mobile phone and click the button to send a one-time use code. Once you receive the code, enter it in the form below.
 
 authenticator-configuration=Authenticator configuration
 verification-code=Verification code
@@ -295,7 +295,7 @@ go-back-to-send=Go back to send
 {description}oauth2-recovery-codes-1=Record these recovery codes, they will not be shown again. Recovery codes can be used to complete a two-factor login or disable two-factor authentication if you lose your device.
 {description}oauth2-recovery-codes-2=Once you have recorded the codes, click Done to continue.
 
-{description}email-verification-required-change-email=Confirm your email address is correct and update it if you mis-typed it during registration. Updating your address will also send you a new email to the new address.
+{description}email-verification-required-change-email=Confirm your email address is correct and update it if you mistyped it during registration. Updating your address will also send you a new email to the new address.
 {description}email-verification-required=You must verify your email address before you continue.
 {description}email-verification-required-non-interactive=Email verification is configured to be completed outside of this request. Once you have verified your email, retry this request.
 
@@ -562,7 +562,7 @@ go-back-to-send=Go back to send
 [ExternalAuthenticationException]OpenIDConnectToken=A request to the OpenID Connect Token API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]OpenIDConnectUserinfo=A request to the OpenID Connect Userinfo API has failed. Unable to complete this login request.
 [ExternalAuthenticationException]SAMLIdPInitiatedIssuerVerificationFailed=The SAML issuer failed validation. Unable to complete this login request.
-[ExternalAuthenticationException]SAMLIdPInitiatedResponseSolicited=The SAML AuthNResponse contained an InResponseTo attribute. In an IdP Initiated Login this is un-expected.
+[ExternalAuthenticationException]SAMLIdPInitiatedResponseSolicited=The SAML AuthnResponse contained an InResponseTo attribute. In an IdP Initiated Login this is un-expected.
 [ExternalAuthenticationException]SAMLResponse=The SAML AuthnResponse object could not be parsed or verified. Unable to complete this login request.
 [ExternalAuthenticationException]SAMLResponseAudienceNotBeforeVerificationFailed=The SAML audience is not yet available to be confirmed. Unable to complete this request.
 [ExternalAuthenticationException]SAMLResponseAudienceNotOnOrAfterVerificationFailed=The SAML audience is no longer eligible to be confirmed. Unable to complete this request.


### PR DESCRIPTION
This addresses the Grammatical errors mentioned in https://github.com/FusionAuth/fusionauth-issues/issues/2251

While translating to German I spotted these few errors in the original English version.