### PR TITLE
refactor(messages.properties): SMS 2FA Message

### DIFF
--- a/theme/messages.properties
+++ b/theme/messages.properties
@@ -252,7 +252,7 @@ two-factor-method-email=Email message
 two-factor-method-sms=Text message
 two-factor-get-code-at-authenticator=Get a code from your authenticator app
 two-factor-get-code-at-email=Get a code at %s\u2026
-two-factor-get-code-at-sms=Get a code at (***) ***-**%s
+two-factor-get-code-at-sms=Get a code at the number ending in %s
 
 # Form input place-holders
 {placeholder}two-factor-code=Enter the one-time code


### PR DESCRIPTION
This addresses the SMS 2FA Message issue mentioned in https://github.com/FusionAuth/fusionauth-issues/issues/2251

Especially for customers with a userbase from multiple countries it is very unlikely to get the number format correct, even with specific Locale. And therefore we would suggest rephrasing it to something more generic.