### PR TITLE
refactor(messages.properties): Return to login messages

### DIFF
--- a/theme/messages.properties
+++ b/theme/messages.properties
@@ -29,7 +29,7 @@ account=Account
 action=Action
 add-two-factor=Add two-factor
 add-webauthn-passkey=Add passkey
-back-to-login=Return to Login
+back-to-login=Return to login
 cancel=Cancel
 captcha-google-branding=This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
 created=Created
@@ -140,7 +140,7 @@ registration-verification-required-title=Verification required
 registration-verification-required-send-another=Send me another email
 relying-party-id=Relying party Id
 return-to-login=Return to login
-return-to-normal-login=Return to the normal login
+return-to-normal-login=Return to normal login
 return-to-webauthn-reauth=Return to passkey authentication
 send-another-code=Send another code
 send-code-to-phone=Send a code to your mobile phone


### PR DESCRIPTION
This addresses the Return to login messages issue mentioned in https://github.com/FusionAuth/fusionauth-issues/issues/2251

`webauthn-reauth-return-to-login` is referencing `return-to-normal-login` and therefore the text needs to be the same.

In addition, login is written lowercase everywhere, so we should write it the same in `back-to-login`.